### PR TITLE
Setup building on circle-ci and publishing to bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,124 @@
+# Scala CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/sample-config/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+      
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+    
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt test:compile
+
+      - save_cache:
+          paths:
+            - "~/.sbt"
+            - "target/resolution-cache"
+            - "target/streams"
+            - "project/target/resolution-cache"
+            - "project/target/streams"
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "build.sbt" }}
+        
+      - run: sbt package
+
+      - persist_to_workspace:
+          # Must be an absolute path, or relative path from working_directory
+          root: ..
+          # Must be relative path from root
+          paths:
+            - repo
+
+  test:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+
+      - attach_workspace:
+          at: /home/circleci
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt test:test
+
+  deploy:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - attach_workspace:
+          at: /home/circleci
+
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "build.sbt" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+
+      - run: sbt publish
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - test:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              only: /.*/
+      - deploy:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /^release-[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,24 @@
-organization in ThisBuild := "lagom-kinesis"
+organization in ThisBuild := "com.streetcontxt"
 scalaVersion in ThisBuild := "2.11.8"
+licenses in ThisBuild += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+bintrayOrganization in ThisBuild := Some("streetcontxt")
+
+resolvers in ThisBuild += Resolver.bintrayRepo("streetcontxt", "maven")
+
+val versionPattern = "release-([0-9\\.]*)".r
+version := sys.props
+  .get("CIRCLE_TAG")
+  .orElse(sys.env.get("CIRCLE_TAG"))
+  .flatMap {
+    case versionPattern(v) => Some(v)
+    case _ => None
+  }
+  .getOrElse("LOCAL-SNAPSHOT")
+
 
 val slf4j = "org.slf4j" % "log4j-over-slf4j" % "1.7.21"
-val akkaStreamKinesisConsumer = "com.contxt" %% "kcl-akka-stream" % "1.0.1-SNAPSHOT"
-val scalaKinesisProducer = "com.contxt" %% "kpl-scala" % "1.0.1-SNAPSHOT"
+val akkaStreamKinesisConsumer = "com.streetcontxt" %% "kcl-akka-stream" % "1.0.3"
+val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "1.0.3"
 val awsJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.11.98"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
 val lagomApi = "com.lightbend.lagom" %% "lagom-api" % "1.3.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.2")
+

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,0 @@
-version in ThisBuild := "1.3.3-SNAPSHOT"


### PR DESCRIPTION
* The build uses a version "LOCAL-SNAPSHOT" unless it is a build triggered by a tag named release-x.x.x, in which case it will use the x.x.x portion of the tag name as the version.
* The build attempts to push releases to a bintray organization named streetcontxt, appropriate values for the BINTRAY_USER and BINTRAY_PASS (actually the API key) environment variables should be set in the circleci project.
* Changed the organization to the full com.streetcontxt domain
* updated the kpl and kcl dependencies to use the latest version published to bintray