### PR TITLE
Add Lagom 1.4/Scala 2.12 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: sbt test:compile
+      - run: sbt +test:compile
 
       - save_cache:
           paths:
@@ -38,7 +38,7 @@ jobs:
             - ~/.m2
           key: v1-dependencies-{{ checksum "build.sbt" }}
         
-      - run: sbt package
+      - run: sbt +package
 
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory
@@ -70,7 +70,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: sbt test:test
+      - run: sbt +test:test
 
   deploy:
     docker:
@@ -94,7 +94,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: sbt publish
+      - run: sbt +publish
 
 workflows:
   version: 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 organization in ThisBuild := "com.streetcontxt"
 scalaVersion in ThisBuild := "2.11.8"
+crossScalaVersions in ThisBuild := Seq("2.11.8", "2.12.4")
 licenses in ThisBuild += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 bintrayOrganization in ThisBuild := Some("streetcontxt")
 
@@ -17,18 +18,18 @@ version in ThisBuild := sys.props
 
 
 val slf4j = "org.slf4j" % "log4j-over-slf4j" % "1.7.21"
-val akkaStreamKinesisConsumer = "com.streetcontxt" %% "kcl-akka-stream" % "1.0.3"
-val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "1.0.3"
+val akkaStreamKinesisConsumer = "com.streetcontxt" %% "kcl-akka-stream" % "LOCAL-SNAPSHOT"
+val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "LOCAL-SNAPSHOT"
 val awsJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.11.98"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
-val lagomApi = "com.lightbend.lagom" %% "lagom-api" % "1.3.0"
-val lagomApiJavaDsl = "com.lightbend.lagom" %% "lagom-javadsl-api" % "1.3.0"
-val lagomApiScalaDsl = "com.lightbend.lagom" %% "lagom-scaladsl-api" % "1.3.0"
-val lagomPersistenceCore = "com.lightbend.lagom" %% "lagom-persistence-core" % "1.3.0"
-val lagomJavadslBroker = "com.lightbend.lagom" %% "lagom-javadsl-broker" % "1.3.0"
-val lagomJavadslServer = "com.lightbend.lagom" %% "lagom-javadsl-server" % "1.3.0"
-val lagomScaladslBroker = "com.lightbend.lagom" %% "lagom-scaladsl-broker" % "1.3.0"
-val lagomScaladslServer = "com.lightbend.lagom" %% "lagom-scaladsl-server" % "1.3.0"
+val lagomApi = "com.lightbend.lagom" %% "lagom-api" % "1.4.4"
+val lagomApiJavaDsl = "com.lightbend.lagom" %% "lagom-javadsl-api" % "1.4.4"
+val lagomApiScalaDsl = "com.lightbend.lagom" %% "lagom-scaladsl-api" % "1.4.4"
+val lagomPersistenceCore = "com.lightbend.lagom" %% "lagom-persistence-core" % "1.4.4"
+val lagomJavadslBroker = "com.lightbend.lagom" %% "lagom-javadsl-broker" % "1.4.4"
+val lagomJavadslServer = "com.lightbend.lagom" %% "lagom-javadsl-server" % "1.4.4"
+val lagomScaladslBroker = "com.lightbend.lagom" %% "lagom-scaladsl-broker" % "1.4.4"
+val lagomScaladslServer = "com.lightbend.lagom" %% "lagom-scaladsl-server" % "1.4.4"
 
 val kinesisProjects = Seq[Project](
   `kinesis-client`,
@@ -84,8 +85,7 @@ lazy val `kinesis-broker` = (project in file("service/core/kinesis/server"))
       scalaKinesisProducer,
       awsJavaSdk,
       lagomApi,
-      lagomPersistenceCore,
-      "org.mock-server" % "mockserver-netty" % "3.10.4"
+      lagomPersistenceCore
     )
   )
   .dependsOn(`kinesis-client`)

--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ version in ThisBuild := sys.props
 
 
 val slf4j = "org.slf4j" % "log4j-over-slf4j" % "1.7.21"
-val akkaStreamKinesisConsumer = "com.streetcontxt" %% "kcl-akka-stream" % "LOCAL-SNAPSHOT"
-val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "LOCAL-SNAPSHOT"
+val akkaStreamKinesisConsumer = "com.streetcontxt" %% "kcl-akka-stream" % "2.0.1"
+val scalaKinesisProducer = "com.streetcontxt" %% "kpl-scala" % "1.0.4"
 val awsJavaSdk = "com.amazonaws" % "aws-java-sdk" % "1.11.98"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
 val lagomApi = "com.lightbend.lagom" %% "lagom-api" % "1.4.4"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/service/core/kinesis/client/src/main/resources/reference.conf
+++ b/service/core/kinesis/client/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-play.crypto.secret = 9cec21cbec8ba9c8c4b00cf3e8acd33e246818ce # A value is required by Play framework.
+play.http.secret.key = 9cec21cbec8ba9c8c4b00cf3e8acd33e246818ce # A value is required by Play framework.
 play.application.loader = com.contxt.example.impl.ExampleLoader
 
 #//#kinesis-broker

--- a/service/javadsl/kinesis/client/src/main/java/com/lightbend/lagom/javadsl/broker/kinesis/KinesisMetadataKeys.java
+++ b/service/javadsl/kinesis/client/src/main/java/com/lightbend/lagom/javadsl/broker/kinesis/KinesisMetadataKeys.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Quotable Value Limited. <https://github.com/Quotable-Value>
+ */
+package com.lightbend.lagom.javadsl.broker.kinesis;
+
+import com.lightbend.lagom.javadsl.api.broker.MetadataKey;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Metadata keys specific to the Kinesis broker implementation.
+ */
+public final class KinesisMetadataKeys {
+
+    private KinesisMetadataKeys() {
+    }
+
+    /** See [[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord.getExplicitHashKey]] for more details. */
+    public static final MetadataKey<Optional<String>> EXPLICIT_HASH_KEY = MetadataKey.named("kinesisExplicitHashKey");
+
+    /** See [[com.amazonaws.services.kinesis.model.Record.getSequenceNumber]] for more details. */
+    public static final MetadataKey<String> SEQUENCE_NUMBER = MetadataKey.named("kinesisSequenceNumber");
+
+    /** See [[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord.getSubSequenceNumber]] for more details. */
+    public static final MetadataKey<OptionalLong> SUB_SEQUENCE_NUMBER = MetadataKey.named("kinesisSubSequenceNumber");
+
+    /** See [[com.amazonaws.services.kinesis.model.Record.getApproximateArrivalTimestamp]] for more details. */
+    public static final MetadataKey<Instant> APPROXIMATE_ARRIVAL_TIMESTAMP = MetadataKey.named("kinesisApproximateArrivalTimestamp");
+
+    /** See [[com.amazonaws.services.kinesis.model.Record.getEncryptionType]] for more details. */
+    public static final MetadataKey<String> ENCRYPTION_TYPE = MetadataKey.named("kinesisEncryptionType");
+
+}

--- a/service/javadsl/kinesis/client/src/main/java/com/lightbend/lagom/javadsl/broker/kinesis/KinesisTopicFactory.java
+++ b/service/javadsl/kinesis/client/src/main/java/com/lightbend/lagom/javadsl/broker/kinesis/KinesisTopicFactory.java
@@ -15,7 +15,7 @@ import com.lightbend.lagom.javadsl.api.ServiceLocator;
 import com.lightbend.lagom.javadsl.api.broker.Topic;
 
 import akka.actor.ActorSystem;
-import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
 import scala.concurrent.ExecutionContext;
 
 /**
@@ -24,13 +24,13 @@ import scala.concurrent.ExecutionContext;
 public class KinesisTopicFactory implements TopicFactory {
     private final ServiceInfo serviceInfo;
     private final ActorSystem system;
-    private final ActorMaterializer materializer;
+    private final Materializer materializer;
     private final ExecutionContext executionContext;
     private final KinesisConfig config;
     private final ServiceLocator serviceLocator;
 
     @Inject
-    public KinesisTopicFactory(ServiceInfo serviceInfo, ActorSystem system, ActorMaterializer materializer,
+    public KinesisTopicFactory(ServiceInfo serviceInfo, ActorSystem system, Materializer materializer,
             ExecutionContext executionContext, ServiceLocator serviceLocator) {
         this.serviceInfo = serviceInfo;
         this.system = system;

--- a/service/javadsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kinesis/JavadslKinesisTopic.scala
+++ b/service/javadsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/javadsl/broker/kinesis/JavadslKinesisTopic.scala
@@ -4,11 +4,13 @@
 package com.lightbend.lagom.internal.javadsl.broker.kinesis
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
+import akka.util.ByteString
 import com.lightbend.lagom.internal.broker.kinesis.KinesisConfig
 import com.lightbend.lagom.javadsl.api.Descriptor.TopicCall
 import com.lightbend.lagom.javadsl.api.broker.Topic.TopicId
 import com.lightbend.lagom.javadsl.api.broker.{Subscriber, Topic}
+import com.lightbend.lagom.javadsl.api.deser.MessageSerializer.NegotiatedDeserializer
 import com.lightbend.lagom.javadsl.api.{ServiceInfo, ServiceLocator}
 
 import scala.concurrent.ExecutionContext
@@ -16,16 +18,23 @@ import scala.concurrent.ExecutionContext
 /**
   * Represents a Kinesis topic and allows publishing/consuming messages to/from the topic.
   */
-private[lagom] class JavadslKinesisTopic[Message](kinesisConfig: KinesisConfig,
-                                                  topicCall: TopicCall[Message],
+private[lagom] class JavadslKinesisTopic[Payload](kinesisConfig: KinesisConfig,
+                                                  topicCall: TopicCall[Payload],
                                                   info: ServiceInfo,
                                                   system: ActorSystem,
                                                   serviceLocator: ServiceLocator)
-                                                 (implicit mat: ActorMaterializer, ec: ExecutionContext)
-  extends Topic[Message] {
+                                                 (implicit mat: Materializer, ec: ExecutionContext)
+  extends Topic[Payload] {
 
   override def topicId: TopicId = topicCall.topicId
 
-  override def subscribe(): Subscriber[Message] = new JavadslKinesisSubscriber(kinesisConfig, topicCall,
-    JavadslKinesisSubscriber.GroupId.default(info), info, system, serviceLocator)
+  private val deserializer: NegotiatedDeserializer[Payload, ByteString] = {
+    val messageSerializer = topicCall.messageSerializer
+    val protocol = messageSerializer.serializerForRequest.protocol
+    messageSerializer.deserializer(protocol)
+  }
+
+  override def subscribe(): Subscriber[Payload] = new JavadslKinesisSubscriber[Payload, Payload](kinesisConfig, topicCall,
+    JavadslKinesisSubscriber.GroupId.default(info), info, system, serviceLocator, kr => deserializer.deserialize(kr.data))
+
 }

--- a/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kinesis/KinesisTopicFactory.scala
+++ b/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kinesis/KinesisTopicFactory.scala
@@ -4,7 +4,7 @@
 package com.lightbend.lagom.internal.scaladsl.broker.kinesis
 
 import akka.actor.ActorSystem
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import com.lightbend.lagom.internal.broker.kinesis.KinesisConfig
 import com.lightbend.lagom.internal.scaladsl.api.broker.TopicFactory
 import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
@@ -18,7 +18,7 @@ import scala.concurrent.ExecutionContext
  */
 private[lagom] class KinesisTopicFactory(serviceInfo: ServiceInfo, system: ActorSystem,
   serviceLocator: ServiceLocator)(implicit
-  materializer: ActorMaterializer,
+  materializer: Materializer,
   executionContext: ExecutionContext) extends TopicFactory {
 
   private val config = KinesisConfig(system.settings.config)

--- a/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kinesis/ScaladslKinesisSubscriber.scala
+++ b/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/internal/scaladsl/broker/kinesis/ScaladslKinesisSubscriber.scala
@@ -8,15 +8,17 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.Done
 import akka.actor.{ActorSystem, SupervisorStrategy}
 import akka.pattern.BackoffSupervisor
-import akka.stream.ActorMaterializer
+import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Source}
-import akka.util.ByteString
+import com.contxt.kinesis.KinesisRecord
 import com.contxt.kinesis.KinesisSource
 import com.lightbend.lagom.internal.broker.kinesis._
 import com.lightbend.lagom.scaladsl.api.Descriptor.TopicCall
+import com.lightbend.lagom.scaladsl.api.broker.Message
+import com.lightbend.lagom.scaladsl.api.broker.MetadataKey
 import com.lightbend.lagom.scaladsl.api.broker.Subscriber
-import com.lightbend.lagom.scaladsl.api.deser.MessageSerializer.NegotiatedDeserializer
 import com.lightbend.lagom.scaladsl.api.{ServiceInfo, ServiceLocator}
+import com.lightbend.lagom.scaladsl.broker.kinesis.KinesisMetadataKeys
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.duration.Duration
@@ -25,16 +27,17 @@ import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 /**
  * A Consumer for consuming messages from kinesis using the gfc-aws-kinesis API.
  */
-class ScaladslKinesisSubscriber[Message](
+class ScaladslKinesisSubscriber[Payload, SubscriberPayload](
   kinesisConfig: KinesisConfig,
-  topicCall: TopicCall[Message],
+  topicCall: TopicCall[Payload],
   groupId: Subscriber.GroupId,
   info: ServiceInfo,
   system: ActorSystem,
-  serviceLocator: ServiceLocator
-)(implicit mat: ActorMaterializer, ec: ExecutionContext)
-  extends Subscriber[Message] {
-  private val log = LoggerFactory.getLogger(classOf[ScaladslKinesisSubscriber[_]])
+  serviceLocator: ServiceLocator,
+  transform: KinesisRecord => SubscriberPayload
+)(implicit mat: Materializer, ec: ExecutionContext)
+  extends Subscriber[SubscriberPayload] {
+  private val log = LoggerFactory.getLogger(classOf[ScaladslKinesisSubscriber[_, _]])
 
   import ScaladslKinesisSubscriber._
 
@@ -43,7 +46,7 @@ class ScaladslKinesisSubscriber[Message](
   private def consumerConfig = ConsumerConfig(system.settings.config)
 
   @throws(classOf[IllegalArgumentException])
-  override def withGroupId(groupId: String): Subscriber[Message] = {
+  override def withGroupId(groupId: String): Subscriber[SubscriberPayload] = {
     val newGroupId = {
       if (groupId == null) {
         val defaultGroupId = GroupId.default(info)
@@ -56,16 +59,24 @@ class ScaladslKinesisSubscriber[Message](
     }
 
     if (newGroupId == this.groupId) this
-    else new ScaladslKinesisSubscriber(kinesisConfig, topicCall, newGroupId, info, system, serviceLocator)
+    else new ScaladslKinesisSubscriber(kinesisConfig, topicCall, newGroupId, info, system, serviceLocator, transform)
   }
 
-  private val deserializer: NegotiatedDeserializer[Message, ByteString] = {
-    val messageSerializer = topicCall.messageSerializer
-    val protocol = messageSerializer.serializerForRequest.protocol
-    messageSerializer.deserializer(protocol)
+  override def withMetadata = new ScaladslKinesisSubscriber[Payload, Message[SubscriberPayload]](
+    kinesisConfig, topicCall, groupId, info, system, serviceLocator, wrapPayload
+  )
+
+  private def wrapPayload(record: KinesisRecord): Message[SubscriberPayload] = {
+    Message(transform(record)) +
+      (MetadataKey.MessageKey[String] -> record.partitionKey) +
+      (KinesisMetadataKeys.ApproximateArrivalTimestamp -> record.approximateArrivalTimestamp) +
+      (KinesisMetadataKeys.EncryptionType -> record.encryptionType) +
+      (KinesisMetadataKeys.ExplicitHashKey -> record.explicitHashKey) +
+      (KinesisMetadataKeys.SequenceNumber -> record.sequenceNumber) +
+      (KinesisMetadataKeys.SubSequenceNumber -> record.subSequenceNumber)
   }
 
-  override def atMostOnceSource: Source[Message, _] = {
+  override def atMostOnceSource: Source[SubscriberPayload, _] = {
 
     val eventualDynamoEndpoint = Future.sequence {
       kinesisConfig.dynamodbServiceName.map { dynamoName =>
@@ -79,7 +90,7 @@ class ScaladslKinesisSubscriber[Message](
     }.toList
     ).map(_.find(_.isDefined).flatten)
 
-    val eventualSource: Future[Source[Message, Future[Done]]] = for {
+    val eventualSource: Future[Source[SubscriberPayload, Future[Done]]] = for {
       kinesisEndpoint <- eventualKinesisEndpoint
       dynamoEndpoint <- eventualDynamoEndpoint
       configuration = KinesisSubscriberActor.buildKinesisStreamConsumerConfig(
@@ -91,49 +102,16 @@ class ScaladslKinesisSubscriber[Message](
         dynamoDbEndpoint = dynamoEndpoint.map(_.toString)
       )
     } yield {
-      KinesisSource(configuration)(mat).map { kr =>
+      KinesisSource(configuration).map { kr =>
         kr.markProcessed()
-        deserializer.deserialize(kr.data)
+        transform(kr)
       }
     }
 
     Await.result(eventualSource, Duration.Inf)
   }
 
-  def committableSource: Source[(Message, () => Unit), _] = {
-    val eventualDynamoEndpoint = Future.sequence(
-      kinesisConfig.dynamodbServiceName.map { dynamoName =>
-      serviceLocator.locate(dynamoName)
-    }.toList
-    ).map(_.find(_.isDefined).flatten)
-
-    val eventualKinesisEndpoint = Future.sequence(
-      kinesisConfig.kinesisServiceName.map { kinesisName =>
-      serviceLocator.locate(kinesisName)
-    }.toList
-    ).map(_.find(_.isDefined).flatten)
-
-    val eventualSource: Future[Source[(Message, () => Unit), Future[Done]]] = for {
-      kinesisEndpoint <- eventualKinesisEndpoint
-      dynamoEndpoint <- eventualDynamoEndpoint
-      configuration = KinesisSubscriberActor.buildKinesisStreamConsumerConfig(
-        consumerConfig = consumerConfig,
-        topicId = topicCall.topicId.name,
-        applicationName = groupId.groupId,
-        kinesisConfig = kinesisConfig,
-        kinesisEndpoint = kinesisEndpoint.map(_.toString),
-        dynamoDbEndpoint = dynamoEndpoint.map(_.toString)
-      )
-    } yield {
-      KinesisSource(configuration)(mat).map { kr =>
-        (deserializer.deserialize(kr.data), kr.markProcessed _)
-      }
-    }
-
-    Await.result(eventualSource, Duration.Inf)
-  }
-
-  override def atLeastOnce(flow: Flow[Message, Done, _]): Future[Done] = {
+  override def atLeastOnce(flow: Flow[SubscriberPayload, Done, _]): Future[Done] = {
     val streamCompleted = Promise[Done]
     val consumerProps = KinesisSubscriberActor.props(
       kinesisConfig,
@@ -142,8 +120,8 @@ class ScaladslKinesisSubscriber[Message](
       topicCall.topicId.name,
       groupId.groupId,
       flow,
-      deserializer.deserialize,
-      streamCompleted
+      streamCompleted,
+      transform
     )
 
     val backoffConsumerProps = BackoffSupervisor.propsWithSupervisorStrategy(

--- a/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kinesis/KinesisMetadataKeys.scala
+++ b/service/scaladsl/kinesis/client/src/main/scala/com/lightbend/lagom/scaladsl/broker/kinesis/KinesisMetadataKeys.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2018 Quotable Value Limited. <https://github.com/Quotable-Value>
+ */
+package com.lightbend.lagom.scaladsl.broker.kinesis
+
+import java.time.Instant
+
+import com.lightbend.lagom.scaladsl.api.broker.MetadataKey
+
+/**
+  * Metadata keys specific to the Kinesis broker implementation.
+  */
+object KinesisMetadataKeys {
+
+  /** See [[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord]] for more details. */
+  val ExplicitHashKey: MetadataKey[Option[String]] = MetadataKey("kinesisExplicitHashKey")
+
+  /** See [[com.amazonaws.services.kinesis.model.Record]] for more details. */
+  val SequenceNumber: MetadataKey[String] = MetadataKey("kinesisSequenceNumber")
+
+  /** See [[com.amazonaws.services.kinesis.clientlibrary.types.UserRecord]] for more details. */
+  val SubSequenceNumber: MetadataKey[Option[Long]] = MetadataKey("kinesisSubSequenceNumber")
+
+  /** See [[com.amazonaws.services.kinesis.model.Record]] for more details. */
+  val ApproximateArrivalTimestamp: MetadataKey[Instant] = MetadataKey("kinesisApproximateArrivalTimestamp")
+
+  /** See [[com.amazonaws.services.kinesis.model.Record]] for more details. */
+  val EncryptionType: MetadataKey[String] = MetadataKey("kinesisEncryptionType")
+
+}


### PR DESCRIPTION
I've been doing some testing with your library that required me to integrate it with Lagom 1.4 and Scala 2.12, which mostly involved adding support for the Subscriber.withMetadata() operation added to the Message Broker API, as well as adding cross-compilation support for Scala 2.11 and 2.12 to match the support provided by Lagom.

A couple of notes:

- You'll probably want this on a separate branch, as you'll lose Lagom 1.3 support with these changes
- The kpl-scala and kpl-akka-stream dependencies are currently set to "LOCAL-SNAPSHOT" as there are no Scala 2.12 versions available in your bintray repository - I've created separate PRs for those libraries.