### PR TITLE
Prevent offset commit when producer.send() fails

### DIFF
--- a/service/core/kinesis/server/src/main/scala/com/lightbend/lagom/internal/broker/kinesis/Producer.scala
+++ b/service/core/kinesis/server/src/main/scala/com/lightbend/lagom/internal/broker/kinesis/Producer.scala
@@ -246,7 +246,7 @@ private[lagom] object Producer {
 
       val producer = ScalaKinesisProducer(topicId, configuration)
 
-      Flow[Message].map(serializer).map(msg => producer.send(msg.partitionKey, msg.data, msg.explicitHashKey))
+      Flow[Message].map(serializer).mapAsync(1)(msg => producer.send(msg.partitionKey, msg.data, msg.explicitHashKey))
     }
 
   }


### PR DESCRIPTION
The flow produced by kinesisFlowPublisher() is currently a Flow[Message, Future[UserRecordResult], _] - the offset is committed as soon as the producer.send() operation returns a Future, regardless of whether or not the Future completes exceptionally, leading to message loss in error scenarios.

Switching to mapAsync() changes the resulting flow to Flow[Message, UserRecordResult, _] - the flow will allow the Futures to complete and correctly propagate any exceptions, preventing offset commit and record loss in error scenarios.